### PR TITLE
Build OTB 9.0.0 with Nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+if ! has nix_direnv_version || ! nix_direnv_version 2.3.0; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.3.0/direnvrc" "sha256-Dmd+j63L84wuzgyjITIfSxSD57Tx7v51DMxVZOsiUD8="
+fi
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-.idea
+.idea/
+.DS_Store
+.direnv

--- a/README.md
+++ b/README.md
@@ -2,6 +2,172 @@
 This repo contains Nix Flake configuration for building [Orfeo Toolbox](https://www.orfeo-toolbox.org/) 
 from source.
 
+## How to use OTB nix package 
+NB: Assuming that one has already Nix with Flake enabled.
+[Check guide](#guide-on-installation-related-to-nix)
+
+1) First create a directory locally `mkdir otb`
+2) Then inside the directory create a `flake.nix` file and copy the content as mentioned below 
+```nix
+{
+  description = "A flake for Orfeo Toolbox";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/24.05";
+    flake-utils.url = "github:numtide/flake-utils";
+    otbpkgs.url = "github:daspk04/otb-nix?ref=1-package-otb";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    otbpkgs,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {inherit system;};
+        otb = otbpkgs.packages.${system}.otb;
+        python = pkgs.python312;
+        pyPkgs = python.pkgs;
+      in {
+        devShells.default = pkgs.mkShell rec {
+          packages = with pkgs; [
+            otb
+            bashInteractive
+            pyPkgs.python
+            pyPkgs.venvShellHook
+          ];
+          venvDir = "./.venv";
+
+          otbPath = with pkgs; pkgs.lib.makeLibraryPath [otb];
+            
+          # add the python path to be able to use otb via python
+          postShellHook = ''
+            export PYTHONPATH="$PYTHONPATH:${otbPath}/otb/python"
+          '';
+        };
+      }
+    );
+}
+```
+3) Then run `nix develop`, this should create a nix shell with python virtual environment `(.venv)`
+with `otb` and `python 3.12` enabled. 
+4) Now one should be able to use all the [command line](https://www.orfeo-toolbox.org/CookBook/CliInterface.html)
+and [python api](https://www.orfeo-toolbox.org/CookBook/PythonAPI.html) as mentioned in documentation.
+
+**Optional:** Step 3 will not be needed if `nix-direnv` is used, it should automatically activate the 
+shell environment when one enters the directory. Incase one has already installed `nix-direnv` then 
+just copy the [.envrc](.envrc) file in this repo and put it inside the above folder.  
+
+
+## Advantage of OTB with Nix
+- This is highly modular and allows one to customize and build `OTB` with a different version of packages 
+as per need such as `GDAL`, `ITK`, etc. as `Nix` already has a lot of [packages]([Nixpkgs](https://search.nixos.org/packages)).
+- Building with Nix is almost reproducible.
+- This was build out of my requirement, as the current OTB build against GDAL does not support `Geo(Parquet)` and `Blosc` 
+compressor for `Zarr` dataset. [Related Issue](https://github.com/remicres/otbtf/issues/95). So this 
+Nix pacakge solved those issues as `GDAL` on `Nixpkgs` already has those.
+- One can combine OTB with different geospatial python libraries such as `rasterio`, `geopandas` etc. 
+which as already available with [Nixpkgs](https://search.nixos.org/packages) no need to create a separate environment.
+- As of today July 2024, there isn't any conda package for OTB, although it is under plan; 
+this Nixpkgs should help people who want to use `OTB` with a different python version or packages 
+such as (gdal,rasterio, geopandas etc.), which should solve most of those use cases for OTB to be 
+imported in an custom python environment.
+
+  
+## Advanced Configuration
+
+1) Python Environment: `OTB` + `Pyotb` + `GDAL` + `Rasterio`.
+Here is an example of how to create an `flake.nix` with all the above python packages.
+`Pyotb` is not available in `Nixpkgs` so we will build it from the source with `Nix`.
+```nix
+{
+  description = "A flake for Orfeo Toolbox";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/24.05";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    otbpkgs.url = "github:daspk04/otb-nix?ref=1-package-otb";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    nixpkgs-unstable,
+    flake-utils,
+    otbpkgs,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {inherit system;};
+        otb = otbpkgs.packages.${system}.otb;
+        python = pkgs.python312;
+        pyPkgs = python.pkgs;
+        
+        # Build configuration pyotb 
+        pyotb = pyPkgs.buildPythonPackage rec {
+          pname = "pyotb";
+          version = "2.0.3.dev2";
+          format = "pyproject";
+          docheck = false;
+         
+        # Fetch it from github (one can fetch from pypi as well)
+          src = builtins.fetchGit {
+            name = pname;
+            url = "https://github.com/orfeotoolbox/pyotb.git";
+            ref = "refs/tags/${version}";
+            rev = "de801eae7e2bd80706801df4a48b23998136a5cd";
+          };
+
+          nativeBuildInputs = with pyPkgs; [
+            setuptools
+          ];
+
+          propagatedBuildInputs = with pyPkgs; [
+            numpy
+          ];
+        };
+      in {
+        devShells.default = pkgs.mkShell rec {
+          packages = with pkgs; [
+            bashInteractive
+            pyPkgs.gdal
+            pypkgs.rasterio
+            pyPkgs.python
+            pyPkgs.venvShellHook
+            pyotb
+            otb
+          ];
+          venvDir = "./.venv";
+
+          otbPath = with pkgs; pkgs.lib.makeLibraryPath [otb];
+
+          postShellHook = ''
+            export PYTHONPATH="$PYTHONPATH:${otbPath}/otb/python"
+          '';
+        };
+      }
+    );
+}
+```
+
+## Develop
+- In case one needs to develop or experiment then
+- Clone this repo and make changes and push to your repository 
+- Then in the above flake change the `otbpkgs.url` to point to the updated repo url.
+```markdown
+otbpkgs.url = "github:{userName}/{repoName}?ref={branchName}";
+```
+
+
+### How to build OTB locally
+```markdown
+1) clone this repo
+2) nix build #.otb
+3) ./result/bin/otbcli_BandMathX -help
+```
 
 ## Guide on installation related to NIX
 
@@ -14,3 +180,11 @@ Nix should be installed and flakes should be enabled.
   - https://www.tweag.io/blog/2020-05-25-flakes/
 - How to install direnv 
   - https://github.com/nix-community/nix-direnv?tab=readme-ov-file#installation
+
+
+## TODO
+ - [ ] Build a Nix Docker for the OTB package 
+ - [ ] Build OTB with [remote modules]((https://www.orfeo-toolbox.org/CookBook/RemoteModules.html)) (OTBTF, TimeSeriesGapFilling, etc)
+
+
+#### **NOTE: This repo is currently experimental, please open an issue in case you encounter any.**

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1717179513,
+        "narHash": "sha256-vboIEwIQojofItm2xGCdZCzW96U85l9nDW3ifMuAIdM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "63dacb46bf939521bdc93981b4cbb7ecb58427a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1719826879,
+        "narHash": "sha256-xs7PlULe8O1SAcs/9e/HOjeUjBrU5FNtkAF/bSEcFto=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b9014df496d5b68bf7c0145d0e9b0f529ce4f2a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "A flake for Orfeo Toolbox";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/24.05";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    nixpkgs-unstable,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {inherit system;};
+        python = pkgs.python312; # we fix python version to 3.12 here for the OTB
+      in rec {
+        packages.shark = pkgs.callPackage ./pkgs/shark/. {inherit system;};
+        packages.itk_4_13 = pkgs.callPackage ./pkgs/itk_4_13_3/. {inherit system;};
+        packages.otb = pkgs.callPackage ./pkgs/otb/. {
+          inherit system;
+          shark = packages.shark;
+          itk_4_13 = packages.itk_4_13;
+          python = python; # build otb with fixed python version
+        };
+        packages.default = packages.otb;
+        devShells.default = pkgs.mkShell rec {
+          packages = with pkgs; [
+            bashInteractive
+            python
+          ];
+        };
+      }
+    );
+}

--- a/pkgs/itk_4_13_3/default.nix
+++ b/pkgs/itk_4_13_3/default.nix
@@ -1,0 +1,166 @@
+{
+  lib,
+  stdenv,
+  fetchgit,
+  cmake,
+  expat,
+  fftw,
+  fftwFloat,
+  gdcm,
+  hdf5-cpp,
+  libjpeg,
+  libminc,
+  libtiff,
+  libpng,
+  libuuid,
+  xz,
+  vtk,
+  zlib,
+  ...
+}: let
+  versionMeta = builtins.fromJSON (builtins.readFile ./version.json);
+in
+  stdenv.mkDerivation rec {
+    pname = "itk";
+    version = versionMeta.version;
+
+    src = builtins.fetchGit {
+      name = pname;
+      url = "https://github.com/InsightSoftwareConsortium/ITK";
+      # version is same as OTB Superbuild
+      # https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/-/blob/develop/SuperBuild/CMake/External_itk.cmake?ref_type=heads#L149
+      ref = "refs/tags/v${version}";
+      rev = versionMeta.rev;
+    };
+
+    # https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/-/tree/develop/SuperBuild/patches/ITK?ref_type=heads
+    # todo: check if all the patches are required for nix
+    patches = [
+      #./itk-1-fftw-all-diff
+      ./itk-2-itktestlib-all.diff
+      ./itk-3-remove-gcc-version-debian-medteam-all.diff
+    ];
+
+    # https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/-/blob/develop/SuperBuild/CMake/External_itk.cmake?ref_type=heads
+    cmakeFlags = [
+      "-DBUILD_TESTING=OFF"
+      "-DBUILD_EXAMPLES=OFF"
+      "-DBUILD_SHARED_LIBS=ON"
+      "-DITK_BUILD_DEFAULT_MODULES=OFF"
+      "-DITKGroup_Core=OFF"
+      "-DITK_FORBID_DOWNLOADS=ON"
+      "-DITK_USE_SYSTEM_LIBRARIES=ON" # finds common libraries e.g. hdf5, libpng, libtiff, libjpeg, zlib etc
+      #   "-DITK_USE_KWSTYLE=OFF"
+      # todo: check if this needs to be enabled as nixpkgs for ITK 5.2.X has this disabled
+      "-DITK_USE_SYSTEM_EIGEN=OFF"
+      #  "-DITK_USE_SYSTEM_EXPAT=ON"
+      #  "-DITK_USE_SYSTEM_ZLIB=ON"
+      #  "-DITK_USE_SYSTEM_TIFF=ON"
+      #  "-DITK_USE_SYSTEM_PNG=ON"
+      "-DModule_ITKCommon=ON"
+      #"-DModule_ITKTestKernel=ON"
+      "-DModule_ITKFiniteDifference=ON"
+      "-DModule_ITKGPUCommon=ON"
+      "-DModule_ITKGPUFiniteDifference=ON"
+      "-DModule_ITKImageAdaptors=ON"
+      "-DModule_ITKImageFunction=ON"
+      "-DModule_ITKMesh=ON"
+      "-DModule_ITKQuadEdgeMesh=ON"
+      "-DModule_ITKSpatialObjects=ON"
+      "-DModule_ITKTransform=ON"
+      "-DModule_ITKTransformFactory=ON"
+      "-DModule_ITKIOTransformBase=ON"
+      "-DModule_ITKIOTransformInsightLegacy=ON"
+      "-DModule_ITKIOTransformMatlab=ON"
+      "-DModule_ITKAnisotropicSmoothing=ON"
+      "-DModule_ITKAntiAlias=ON"
+      "-DModule_ITKBiasCorrection=ON"
+      "-DModule_ITKBinaryMathematicalMorphology=ON"
+      "-DModule_ITKColormap=ON"
+      "-DModule_ITKConvolution=ON"
+      "-DModule_ITKCurvatureFlow=ON"
+      "-DModule_ITKDeconvolution=ON"
+      "-DModule_ITKDenoising=ON"
+      #-DModule_ITKDiffusionTensorImage=ON
+      "-DModule_ITKDisplacementField=ON"
+      "-DModule_ITKDistanceMap=ON"
+      "-DModule_ITKFastMarching=ON"
+      "-DModule_ITKFFT=ON"
+      "-DModule_ITKGPUAnisotropicSmoothing=ON"
+      "-DModule_ITKGPUImageFilterBase=ON"
+      "-DModule_ITKGPUSmoothing=ON"
+      "-DModule_ITKGPUThresholding=ON"
+      "-DModule_ITKImageCompare=ON"
+      "-DModule_ITKImageCompose=ON"
+      "-DModule_ITKImageFeature=ON"
+      "-DModule_ITKImageFilterBase=ON"
+      "-DModule_ITKImageFusion=ON"
+      "-DModule_ITKImageGradient=ON"
+      "-DModule_ITKImageGrid=ON"
+      "-DModule_ITKImageIntensity=ON"
+      "-DModule_ITKImageLabel=ON"
+      "-DModule_ITKImageSources=ON"
+      "-DModule_ITKImageStatistics=ON"
+      "-DModule_ITKLabelMap=ON"
+      "-DModule_ITKMathematicalMorphology=ON"
+      "-DModule_ITKPath=ON"
+      "-DModule_ITKQuadEdgeMeshFiltering=ON"
+      "-DModule_ITKSmoothing=ON"
+      "-DModule_ITKSpatialFunction=ON"
+      "-DModule_ITKThresholding=ON"
+      "-DModule_ITKEigen=ON"
+      #"-DModule_ITKFEM=ON"
+      "-DModule_ITKNarrowBand=ON"
+      "-DModule_ITKNeuralNetworks=ON"
+      "-DModule_ITKOptimizers=ON"
+      "-DModule_ITKOptimizersv4=ON"
+      "-DModule_ITKPolynomials=ON"
+      "-DModule_ITKStatistics=ON"
+      "-DModule_ITKRegistrationCommon=ON"
+      #"-DModule_ITKFEMRegistration=ON"
+      "-DModule_ITKGPURegistrationCommon=ON"
+      "-DModule_ITKGPUPDEDeformableRegistration=ON"
+      "-DModule_ITKMetricsv4=ON"
+      "-DModule_ITKPDEDeformableRegistration=ON"
+      "-DModule_ITKRegistrationMethodsv4=ON"
+      #"-DModule_ITKBioCell=ON"
+      "-DModule_ITKClassifiers=ON"
+      "-DModule_ITKConnectedComponents=ON"
+      "-DModule_ITKDeformableMesh=ON"
+      "-DModule_ITKKLMRegionGrowing=ON"
+      "-DModule_ITKLabelVoting=ON"
+      "-DModule_ITKLevelSets=ON"
+      "-DModule_ITKLevelSetsv4=ON"
+      #"-DModule_ITKLevelSetsv4Visualization=ON"
+      "-DModule_ITKMarkovRandomFieldsClassifiers=ON"
+      "-DModule_ITKRegionGrowing=ON"
+      "-DModule_ITKSignedDistanceFunction=ON"
+      "-DModule_ITKVoronoi=ON"
+      "-DModule_ITKWatersheds=ON"
+    ];
+
+    nativeBuildInputs = [cmake xz];
+    buildInputs = [
+      libuuid
+    ];
+    propagatedBuildInputs = [
+      # The dependencies we've un-vendored from ITK, must be propagated,
+      # otherwise other software built against ITK fails to configure since ITK headers
+      # refer to these previously vendored libraries:
+      expat
+      fftw
+      fftwFloat
+      hdf5-cpp
+      libjpeg
+      libpng
+      libtiff
+      zlib
+    ];
+
+    meta = {
+      description = "Insight Segmentation and Registration Toolkit";
+      homepage = "https://www.itk.org";
+      license = lib.licenses.asl20;
+      maintainers = with lib.maintainers; [daskpk04];
+    };
+  }

--- a/pkgs/itk_4_13_3/itk-1-fftw-all.diff
+++ b/pkgs/itk_4_13_3/itk-1-fftw-all.diff
@@ -1,0 +1,31 @@
+diff -burN InsightToolkit-4.10.0.orig/CMake/FindFFTW.cmake InsightToolkit-4.10.0/CMake/FindFFTW.cmake
+--- InsightToolkit-4.10.0.orig/CMake/FindFFTW.cmake	2016-06-16 14:21:15.226203872 +0200
++++ InsightToolkit-4.10.0/CMake/FindFFTW.cmake	2016-06-16 14:23:48.966202670 +0200
+@@ -35,14 +35,12 @@
+   set(FFTW_LIB_SEARCHPATH
+     ${FFTW_INSTALL_BASE_PATH}/lib
+     ${FFTW_INSTALL_BASE_PATH}/lib64
+-    /usr/lib/fftw
+-    /usr/local/lib/fftw
+   )
+ 
+   if(ITK_USE_FFTWD)
+     mark_as_advanced(FFTWD_LIB)
+-    find_library(FFTWD_LIB fftw3 ${FFTW_LIB_SEARCHPATH}) #Double Precision Lib
+-    find_library(FFTWD_THREADS_LIB fftw3_threads ${FFTW_LIB_SEARCHPATH}) #Double Precision Lib only if compiled with threads support
++    find_library(FFTWD_LIB fftw3 ${FFTW_LIB_SEARCHPATH} NO_DEFAULT_PATH) #Double Precision Lib
++    find_library(FFTWD_THREADS_LIB fftw3_threads ${FFTW_LIB_SEARCHPATH} NO_DEFAULT_PATH) #Double Precision Lib only if compiled with threads support
+ 
+     if(FFTWD_LIB)
+       set(FFTWD_FOUND 1)
+@@ -55,8 +53,8 @@
+ 
+   if(ITK_USE_FFTWF)
+     mark_as_advanced(FFTWF_LIB)
+-    find_library(FFTWF_LIB fftw3f ${FFTW_LIB_SEARCHPATH}) #Single Precision Lib
+-    find_library(FFTWF_THREADS_LIB fftw3f_threads ${FFTW_LIB_SEARCHPATH}) #Single Precision Lib only if compiled with threads support
++    find_library(FFTWF_LIB fftw3f ${FFTW_LIB_SEARCHPATH} NO_DEFAULT_PATH) #Single Precision Lib
++    find_library(FFTWF_THREADS_LIB fftw3f_threads ${FFTW_LIB_SEARCHPATH} NO_DEFAULT_PATH) #Single Precision Lib only if compiled with threads support
+ 
+     if(FFTWF_LIB)
+       set(FFTWF_FOUND 1)

--- a/pkgs/itk_4_13_3/itk-2-itktestlib-all.diff
+++ b/pkgs/itk_4_13_3/itk-2-itktestlib-all.diff
@@ -1,0 +1,35 @@
+diff -burN InsightToolkit-4.12.0.orig/Modules/ThirdParty/VNL/src/CMakeLists.txt InsightToolkit-4.12.0/Modules/ThirdParty/VNL/src/CMakeLists.txt
+--- InsightToolkit-4.12.0.orig/Modules/ThirdParty/VNL/src/CMakeLists.txt	2017-08-22 11:53:55.960938649 +0200
++++ InsightToolkit-4.12.0/Modules/ThirdParty/VNL/src/CMakeLists.txt	2017-08-22 11:56:07.289820954 +0200
+@@ -18,10 +18,14 @@
+ # Retrive the variable type to CACHE.
+ set(BUILD_EXAMPLES ${BUILD_EXAMPLES} CACHE BOOL "Build the examples from the ITK Software Guide." FORCE)
+ 
+-foreach(lib itkvcl itkv3p_netlib itktestlib itkvnl itkvnl_algo itknetlib)
++foreach(lib itkvcl itkv3p_netlib itkvnl itkvnl_algo itknetlib)
+   itk_module_target(${lib} NO_INSTALL)
+ endforeach()
+ 
++if(BUILD_TESTING)
++  itk_module_target(itktestlib NO_INSTALL)
++endif()
++
+ foreach(exe
+     netlib_integral_test
+     netlib_lbfgs_example
+diff -burN InsightToolkit-4.12.0.orig/Modules/ThirdParty/VNL/src/vxl/core/CMakeLists.txt InsightToolkit-4.12.0/Modules/ThirdParty/VNL/src/vxl/core/CMakeLists.txt
+--- InsightToolkit-4.12.0.orig/Modules/ThirdParty/VNL/src/vxl/core/CMakeLists.txt	2017-08-22 11:53:55.960938649 +0200
++++ InsightToolkit-4.12.0/Modules/ThirdParty/VNL/src/vxl/core/CMakeLists.txt	2017-08-22 11:56:56.410150930 +0200
+@@ -131,8 +131,10 @@
+   set(CORE_VIDEO_FOUND OFF CACHE INTERNAL "VXL core video libraries built")
+ endif ()
+ 
+-# common test executable
+-add_subdirectory(testlib)
++# common test executable if testing enabled
++if(BUILD_TESTING)
++  add_subdirectory(testlib)
++endif()
+ 
+ # Tests that check and output the vxl configuration
+ # NOTE: some external projects remove the tests directory (aka ITK)

--- a/pkgs/itk_4_13_3/itk-3-remove-gcc-version-debian-medteam-all.diff
+++ b/pkgs/itk_4_13_3/itk-3-remove-gcc-version-debian-medteam-all.diff
@@ -1,0 +1,104 @@
+--- a/Modules/ThirdParty/VNL/src/vxl/vcl/vcl_compiler.h
++++ b/Modules/ThirdParty/VNL/src/vxl/vcl/vcl_compiler.h
+@@ -43,85 +43,7 @@
+ #endif
+ 
+ #if defined(__GNUC__) && !defined(__ICC) // icc 8.0 defines __GNUC__
+-# define VCL_GCC
+-# if (__GNUC__ < 4)
+-#  error "forget it."
+-# elif (__GNUC__==4)
+-#  define VCL_GCC_4
+-#  if (__GNUC_MINOR__ > 0 )
+-#   define VCL_GCC_41
+-#  else
+-#   define VCL_GCC_40
+-#  endif
+-# elif (__GNUC__==5)
+-#  define VCL_GCC_5
+-#  if (__GNUC_MINOR__ > 2 )
+-#   define VCL_GCC_53
+-#  elif (__GNUC_MINOR__ > 1 )
+-#   define VCL_GCC_52
+-#  elif (__GNUC_MINOR__ > 0 )
+-#   define VCL_GCC_51
+-#  else
+-#   define VCL_GCC_50
+-#  endif
+-# elif (__GNUC__==6)
+-#  define VCL_GCC_6
+-#  if (__GNUC_MINOR__ > 2 )
+-#   define VCL_GCC_63
+-#  elif (__GNUC_MINOR__ > 1 )
+-#   define VCL_GCC_62
+-#  elif (__GNUC_MINOR__ > 0 )
+-#   define VCL_GCC_61
+-#  else
+-#   define VCL_GCC_60
+-#  endif
+-# elif (__GNUC__==7)
+-#  define VCL_GCC_7
+-#  if (__GNUC_MINOR__ > 2 )
+-#   define VCL_GCC_73
+-#  elif (__GNUC_MINOR__ > 1 )
+-#   define VCL_GCC_72
+-#  elif (__GNUC_MINOR__ > 0 )
+-#   define VCL_GCC_71
+-#  else
+-#   define VCL_GCC_70
+-#  endif
+-# elif (__GNUC__==8)
+-#  define VCL_GCC_8
+-#  if (__GNUC_MINOR__ > 2 )
+-#   define VCL_GCC_83
+-#  elif (__GNUC_MINOR__ > 1 )
+-#   define VCL_GCC_82
+-#  elif (__GNUC_MINOR__ > 0 )
+-#   define VCL_GCC_81
+-#  else
+-#   define VCL_GCC_80
+-#  endif
+-# elif (__GNUC__==9)
+-#  define VCL_GCC_9
+-#  if (__GNUC_MINOR__ > 2 )
+-#   define VCL_GCC_93
+-#  elif (__GNUC_MINOR__ > 1 )
+-#   define VCL_GCC_92
+-#  elif (__GNUC_MINOR__ > 0 )
+-#   define VCL_GCC_91
+-#  else
+-#   define VCL_GCC_90
+-#  endif
+-# elif (__GNUC__==10)
+-#  define VCL_GCC_10
+-#  if (__GNUC_MINOR__ > 2 )
+-#   define VCL_GCC_103
+-#  elif (__GNUC_MINOR__ > 1 )
+-#   define VCL_GCC_102
+-#  elif (__GNUC_MINOR__ > 0 )
+-#   define VCL_GCC_101
+-#  else
+-#   define VCL_GCC_100
+-#  endif
+-# else
+-#  error "Dunno about this gcc"
+-# endif
++# define VCL_GCC_73
+ #endif
+ 
+ #if defined(_WIN32) || defined(WIN32)
+--- a/Modules/ThirdParty/VNL/src/vxl/vcl/tests/test_preprocessor.cxx
++++ b/Modules/ThirdParty/VNL/src/vxl/vcl/tests/test_preprocessor.cxx
+@@ -64,6 +64,12 @@
+   ++minor_count;
+ #endif
+ 
++#ifdef VCL_GCC_73
++  ++compiler_count;
++  ++major_count;
++  ++minor_count;
++#endif
++
+ #ifdef VCL_VC
+   ++compiler_count;
+ #endif

--- a/pkgs/itk_4_13_3/version.json
+++ b/pkgs/itk_4_13_3/version.json
@@ -1,0 +1,4 @@
+{
+  "version": "4.13.3",
+  "rev": "f7ac08b4c96cb0cc5ecc6c2d5ef9fcbd17f613f8"
+}

--- a/pkgs/otb/default.nix
+++ b/pkgs/otb/default.nix
@@ -1,0 +1,115 @@
+{
+  cmake,
+  stdenv,
+  swig,
+  which,
+  boost,
+  curl,
+  gdal,
+  itk_4_13,
+  libsvm,
+  libgeotiff,
+  muparser,
+  muparserx,
+  opencv,
+  perl,
+  python,
+  shark,
+  tinyxml,
+  makeWrapper,
+  fetchgit,
+  lib,
+  pkgs,
+  ...
+}: let
+  versionMeta = builtins.fromJSON (builtins.readFile ./version.json);
+in
+  stdenv.mkDerivation rec {
+    pname = "otb";
+    version = versionMeta.version;
+
+    src = builtins.fetchGit {
+      name = pname;
+      url = "https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb";
+      ref = "refs/tags/${version}";
+      rev = versionMeta.rev;
+    };
+
+
+    nativeBuildInputs = [
+      cmake
+      makeWrapper
+      python.pkgs.wrapPython
+      swig
+      which
+    ];
+
+    buildInputs = [
+      boost
+      curl
+      gdal
+      itk_4_13
+      libsvm
+      libgeotiff
+      muparser
+      muparserx
+      opencv
+      perl
+      python
+      python.pkgs.numpy
+      shark
+      tinyxml
+    ];
+
+
+    # https://www.orfeo-toolbox.org/CookBook/CompilingOTBFromSource.html#native-build-with-system-dependencies
+    # activates all modules and python by default
+    # todo: make modules as optional flag, possibly can have similar as gdal package in nix, otbminimal, otbcore ?
+    cmakeFlags = [
+      "-DOTB_WRAP_PYTHON=ON"
+      "-DOTB_BUILD_FeaturesExtraction=ON"
+      "-DOTB_BUILD_Hyperspectral=ON"
+      "-DOTB_BUILD_Learning=ON"
+      "-DOTB_BUILD_Miscellaneous=ON"
+      "-DOTB_BUILD_RemoteModules=ON"
+      "-DOTB_BUILD_SAR=ON"
+      "-DOTB_BUILD_Segmentation=ON"
+      "-DOTB_BUILD_StereoProcessing=ON"
+      "-DBUILD_TESTING=OFF"
+    ];
+
+    # todo: check if these contains all the required packages for another package to be build against OTB (such remote modules) ?
+    propagatedBuildInputs = [
+      boost
+      curl
+      gdal
+      itk_4_13
+      libgeotiff
+      libsvm
+      muparser
+      muparserx
+      opencv
+      perl
+      python
+      python.pkgs.numpy
+      shark
+      swig
+      tinyxml
+    ];
+
+    pythonPath = [python.pkgs.numpy];
+
+    # wrap the otbcli with the environment variable
+    postInstall = ''
+      wrapProgram $out/bin/otbcli \
+          --set OTB_INSTALL_DIR "$out" \
+          --set OTB_APPLICATION_PATH "$out/lib/otb/applications"
+    '';
+
+    meta = {
+      description = "Orfeo ToolBox";
+      homepage = "https://www.orfeo-toolbox.org/";
+      license = lib.licenses.asl20;
+      maintainers = with lib.maintainers; [daspk04];
+    };
+  }

--- a/pkgs/otb/version.json
+++ b/pkgs/otb/version.json
@@ -1,0 +1,4 @@
+{
+  "version": "9.0.0",
+  "rev": "d39a6fcbe9762e3267b461d551e5cbe820dbd4e4"
+}

--- a/pkgs/shark/default.nix
+++ b/pkgs/shark/default.nix
@@ -1,0 +1,54 @@
+{
+  stdenv,
+  fetchgit,
+  cmake,
+  boost,
+  openssl,
+  pkgs,
+  ...
+}: let
+  versionMeta = builtins.fromJSON (builtins.readFile ./version.json);
+in
+  stdenv.mkDerivation rec {
+    pname = "shark";
+    # fetch the latest master, differs from otb superbuild which was last updated 2 years back
+    version = versionMeta.version;
+
+    src = builtins.fetchGit {
+      name = pname;
+      url = "https://github.com/Shark-ML/Shark";
+      ref = "master";
+      rev = versionMeta.rev;
+    };
+
+    # todo: check if patches are needed for nix
+    # https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/-/tree/develop/SuperBuild/patches/SHARK?ref_type=heads
+    # patch of hdf5 seems to be not needed based on latest master branch of shark-ml as HDF5 has been removed
+    # c.f https://github.com/Shark-ML/Shark/commit/221c1f2e8abfffadbf3c5ef7cf324bc6dc9b4315
+    #    patches = [
+    #        ./shark-1-disable-hdf5-all.diff
+    #        ./shark-2-ext-num-literals-all.diff
+    #    ];
+
+    # https://gitlab.orfeo-toolbox.org/orfeotoolbox/otb/-/blob/develop/SuperBuild/CMake/External_shark.cmake?ref_type=heads
+    cmakeFlags = [
+      "-DBUILD_SHARED_LIBS=ON"
+      "-DBUILD_EXAMPLES=OFF"
+      "-DBUILD_DOCS=OFF"
+      "-DBUILD_TESTING=OFF"
+      #      "-DENABLE_HDF5=OFF" no more needed based on latest master
+      "-DENABLE_CBLAS=OFF"
+      "-DENABLE_OPENMP=OFF" # otb has this as optional flag during superbuild, make this as optional flag in nix
+    ];
+    buildInputs = [
+      boost
+      openssl
+    ];
+
+    nativeBuildInputs = [cmake];
+
+    meta = {
+      description = "The Shark Machine Leaning Library";
+      homepage = "http://shark-ml.github.io/Shark/";
+    };
+  }

--- a/pkgs/shark/shark-1-disable-hdf5-all.diff
+++ b/pkgs/shark/shark-1-disable-hdf5-all.diff
@@ -1,0 +1,21 @@
+diff -burN Shark.orig/CMakeLists.txt Shark/CMakeLists.txt
+--- Shark.orig/CMakeLists.txt	2016-09-02 17:04:54.000000000 +0200
++++ Shark/CMakeLists.txt	2017-07-31 16:41:18.563473752 +0200
+@@ -194,6 +194,8 @@
+ #####################################################################
+ #           HDF5 configuration
+ #####################################################################
++option(ENABLE_HDF5 "Use HDF5" ON)
++if(ENABLE_HDF5)
+ find_package(HDF5 COMPONENTS C CXX HL QUIET)
+ mark_as_advanced(HDF5_DIR)
+ if(HDF5_FOUND)
+@@ -215,7 +217,7 @@
+ else()
+ 	message(STATUS "HDF5 not found, skip")
+ endif()
+-
++endif() #ENABLE_HDF5
+ #####################################################################
+ #           ATLAS configuration
+ #####################################################################

--- a/pkgs/shark/shark-2-ext-num-literals-all.diff
+++ b/pkgs/shark/shark-2-ext-num-literals-all.diff
@@ -1,0 +1,13 @@
+diff -burN Shark.orig/CMakeLists.txt Shark/CMakeLists.txt
+--- Shark.orig/CMakeLists.txt	2018-02-05 18:04:58.012612932 +0100
++++ Shark/CMakeLists.txt	2018-02-05 18:20:50.032233165 +0100
+@@ -415,6 +415,9 @@
+ #####################################################################
+ #                       General Path settings
+ #####################################################################
++if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
++  add_definitions(-fext-numeric-literals)
++endif()
+ include_directories( ${shark_SOURCE_DIR}/include )
+ include_directories( ${shark_BINARY_DIR}/include )
+ add_subdirectory( include )

--- a/pkgs/shark/version.json
+++ b/pkgs/shark/version.json
@@ -1,0 +1,4 @@
+{
+  "version": "4.1.0",
+  "rev": "16a7cecf1c012ceaa406e3a5af54d1a6a47d5cda"
+}


### PR DESCRIPTION
This builds the OTB 9.0.0 with nix, this complies OTB from the source as per [documentation](https://www.orfeo-toolbox.org/CookBook/CompilingOTBFromSource.html#compiling-otb-from-source). The version of the libraries used for building OTB via Nix package might vary from the Superbuild version as this is a Native build. [c.f](https://www.orfeo-toolbox.org/CookBook/CompilingOTBFromSource.html#system-dependencies-to-build-from-source)

Version of the Nix Packages used for building OTB 9.0.0

* glibc-2.39-52
* bash-5.2p26
* zlib-1.3.1
* gcc-13.2.0-lib
* opencv-4.9.0
* perl-5.38.2
* curl-8.7.1
* boost-1.81.0
* tinyxml-2.6.2
* libsvm-3.32
* libsvm-3.32-dev
* muparser-2.3.4
* python3-3.12.3
* libgeotiff-1.7.1-dev
* gdal-3.8.5
* zlib-1.3.1-dev
* curl-8.7.1-dev
* python3.12-numpy-1.26.4
* swig-3.0.12
* itk-4.13.3
* boost-1.81.0-dev
* shark-4.1.0
* muparserx-4.0.12