### PR TITLE
[BUILD] Update nixpkgs and enhance OTB build environment

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -88,16 +88,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1717179513,
-        "narHash": "sha256-vboIEwIQojofItm2xGCdZCzW96U85l9nDW3ifMuAIdM=",
+        "lastModified": 1735922141,
+        "narHash": "sha256-vk0xwGZSlvZ/596yxOtsk4gxsIx2VemzdjiU8zhjgWw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "63dacb46bf939521bdc93981b4cbb7ecb58427a0",
+        "rev": "d29ab98cd4a70a387b8ceea3e930b3340d41ac5a",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,7 @@
   description = "A flake for Orfeo Toolbox";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/24.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     nix2container.url = "github:nlewo/nix2container";

--- a/pkgs/otb/default.nix
+++ b/pkgs/otb/default.nix
@@ -13,6 +13,7 @@
 #   limitations under the License.
 {
   cmake,
+  clangStdenv,
   fetchFromGitHub,
   makeWrapper,
   lib,
@@ -58,6 +59,8 @@
   pkgs,
   ...
 }: let
+
+  stdenv = clangStdenv;
 
   inherit (lib) optionalString optionals optional;
   pythonInputs =


### PR DESCRIPTION
* Upgraded nixpkgs to nixos-24.11 and updated `flake.lock` accordingly.

* Change OTB build setup to use `clangStdenv` as the default environment.